### PR TITLE
chore: Add files property to package.json to reduce the npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/pricelinelabs/es-router"
   },
+  "files": ["es-router.*.js"],
   "babel": {
     "presets": [
       "es2015"


### PR DESCRIPTION
I wrote [npm-unpack](https://www.npmjs.com/package/npm-unpack) which can tell you what files are included in your package. Before this PR, this package includes:

```
$ npm-unpack

package.json
.npmignore
README.md
LICENSE
es-router.min.js
es-router.js
gulpfile.babel.js
.eslintrc
gulp/build.js
gulp/gulp-config.js
gulp/test.js
gulp/core/modules.js
src/es-router.js
test/sample.spec.js
```

After this PR, it includes:

```
$ npm-unpack

package.json
README.md
LICENSE
es-router.js
es-router.min.js
```

^ Just the minimum needed to publish to npm

Keeping the package size as small as possible increases the speed by which it downloads when npm installing.
