### PR TITLE
feat(test): add coverage gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ bower_components
 
 # Build
 tmp
+
+# Test
+coverage/

--- a/gulp/test.js
+++ b/gulp/test.js
@@ -1,8 +1,26 @@
 import gulp from 'gulp';
+import istanbul from 'gulp-istanbul';
 import jasmine from 'gulp-jasmine';
-import { testFiles } from './gulp-config';
+import { scriptSourceFiles, testFiles } from './gulp-config';
 
-gulp.task('test', function () {
+gulp.task('pre-test', function () {
+  return gulp.src(scriptSourceFiles)
+    .pipe(istanbul())
+    .pipe(istanbul.hookRequire());
+});
+
+gulp.task('test', ['pre-test'], function () {
   return gulp.src(testFiles)
-    .pipe(jasmine());
+    .pipe(jasmine())
+    .pipe(istanbul.writeReports())
+    .pipe(istanbul.enforceThresholds({
+      thresholds: {
+        global: {
+          statements: 67.55,
+          branches: 60.95,
+          functions: 80,
+          lines: 67.83
+        }
+      }
+    }));
 });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-babel": "^6.1.1",
     "gulp-eslint": "2.1.0",
     "gulp-iife": "^0.2.4",
+    "gulp-istanbul": "^1.1.1",
     "gulp-jasmine": "^2.2.1",
     "gulp-load-plugins": "^1.2.0",
     "gulp-plumber": "^0.6.6",


### PR DESCRIPTION
Adding a pre-test task to introduce coverage as a gate. Setting the initial thresholds at the current coverage percentages. Ultimately, we'd want it to be 100% global.